### PR TITLE
altered sorted_search to not return the input word

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ venv.bak/
 .vscode/*
 *.ipynb
 .pypirc
+/.vs

--- a/Phyme/Phyme.py
+++ b/Phyme/Phyme.py
@@ -44,6 +44,14 @@ class Phyme(object):
         sorted_dict = dict()
         for k, v in results.items():
             sorted_dict[k] = list(sort_words(keyword, v))
+
+        #This removes the input word from the return of rhymes
+        for syl in sorted_dict:
+            try:
+                sorted_dict[syl].remove(keyword)
+            except:
+                pass
+
         return sorted_dict
 
     def get_perfect_rhymes(self, word, num_syllables=None):


### PR DESCRIPTION
Hey, new to this so sorry to bug you if this is dumb, but I recently used Phyme to make a sonnet bot, and found it useful to prevent the input word from being in the return list.  I know it's suuuper basic and just adds a couple lines to sorted_search, but just in case you think this might be an improvement, I thought I'd put it out there.  Either way, thank you for this awesome library!